### PR TITLE
Add .gitignore file to exclude logs, build artifacts, and editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+
+.env
+seed.js


### PR DESCRIPTION
### What this PR does
Adds a `.gitignore` file to prevent sensitive and unnecessary files from being tracked and pushed to the repository.

### Files ignored
1. `.env` — contains sensitive credentials and environment variables
2. `Seed.js` — database seeder file, not needed in version control
3. Build artifacts, logs, and editor-specific files

### Why
The `.env` and `Seed.js` files were previously pushed to the repo, exposing critical project details. This fix ensures they will not be committed again in the future.

### Related Issue
Closes #1 